### PR TITLE
Twitter認証でログインできるようにした

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,6 @@ inherit_gem:
   rubocop-fjord:
     - "config/rubocop.yml"
     - "config/rails.yml"
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
 
   # not default
+  gem 'dotenv-rails'
   gem 'factory_bot_rails'
   gem 'rspec-rails'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'webpacker', '~> 5.0'
 # not default
 gem 'meta-tags'
 gem 'slim-rails'
+gem 'omniauth-twitter'
 
 group :production do
   gem 'aws-sdk-s3', require: false
@@ -51,3 +52,4 @@ group :test do
 end
 
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+

--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,9 @@ gem 'webpacker', '~> 5.0'
 
 # not default
 gem 'meta-tags'
-gem 'slim-rails'
 gem 'omniauth-rails_csrf_protection'
 gem 'omniauth-twitter'
+gem 'slim-rails'
 
 group :production do
   gem 'aws-sdk-s3', require: false
@@ -53,4 +53,3 @@ group :test do
 end
 
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
-

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'webpacker', '~> 5.0'
 # not default
 gem 'meta-tags'
 gem 'slim-rails'
+gem 'omniauth-rails_csrf_protection'
 gem 'omniauth-twitter'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
     ffi (1.15.4)
     globalid (0.5.2)
       activesupport (>= 5.0)
+    hashie (4.1.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
@@ -134,6 +135,17 @@ GEM
       racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
+    oauth (0.5.6)
+    omniauth (2.0.4)
+      hashie (>= 3.4.6)
+      rack (>= 1.6.2, < 3)
+      rack-protection
+    omniauth-oauth (1.2.0)
+      oauth
+      omniauth (>= 1.0, < 3)
+    omniauth-twitter (1.4.0)
+      omniauth-oauth (~> 1.1)
+      rack
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -145,6 +157,8 @@ GEM
     rack (2.2.3)
     rack-mini-profiler (2.3.3)
       rack (>= 1.2.0)
+    rack-protection (2.1.0)
+      rack
     rack-proxy (0.7.0)
       rack
     rack-test (1.1.0)
@@ -300,6 +314,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (~> 3.3)
   meta-tags
+  omniauth-twitter
   pg (~> 1.1)
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,9 @@ GEM
     omniauth-oauth (1.2.0)
       oauth
       omniauth (>= 1.0, < 3)
+    omniauth-rails_csrf_protection (1.0.0)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     omniauth-twitter (1.4.0)
       omniauth-oauth (~> 1.1)
       rack
@@ -314,6 +317,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (~> 3.3)
   meta-tags
+  omniauth-rails_csrf_protection
   omniauth-twitter
   pg (~> 1.1)
   puma (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,10 @@ GEM
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     diff-lcs (1.4.4)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
@@ -291,6 +295,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
+  dotenv-rails
   factory_bot_rails
   jbuilder (~> 2.7)
   listen (~> 3.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  include SessionsHelper
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,11 @@
 
 class ApplicationController < ActionController::Base
   include SessionsHelper
+  before_action :login_required
+
+  private
+
+  def login_required
+    redirect_to welcome_url unless current_user
+  end
 end

--- a/app/controllers/code_controller.rb
+++ b/app/controllers/code_controller.rb
@@ -4,7 +4,8 @@ class CodeController < ApplicationController
   before_action :set_code, only: %i[show destroy]
 
   def index
-    @code = Code.all
+    @user = User.find(params[:user_id] || current_user.id)
+    @code = @user.code
   end
 
   def show

--- a/app/controllers/code_controller.rb
+++ b/app/controllers/code_controller.rb
@@ -16,7 +16,7 @@ class CodeController < ApplicationController
   end
 
   def create
-    @code = Code.new(code_params)
+    @code = current_user.code.new(code_params)
     @code.attach_blob(image_data_url)
 
     if @code.save

--- a/app/controllers/code_controller.rb
+++ b/app/controllers/code_controller.rb
@@ -29,7 +29,7 @@ class CodeController < ApplicationController
 
   def destroy
     @code.destroy
-    redirect_to code_index_url, notice: 'Code was successfully destroyed.'
+    redirect_to user_code_index_path(current_user.id), notice: 'Code was successfully destroyed.'
   end
 
   private

--- a/app/controllers/code_controller.rb
+++ b/app/controllers/code_controller.rb
@@ -2,6 +2,7 @@
 
 class CodeController < ApplicationController
   before_action :set_code, only: %i[show destroy]
+  skip_before_action :login_required, only: %i[show index]
 
   def index
     @user = User.find(params[:user_id] || current_user.id)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SessionsController < ApplicationController
+  def create
+    user_data = request.env['omniauth.auth']
+    session[:nickname] = user_data[:info][:nickname]
+    redirect_to root_path, notice: 'ログインしました'
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -24,6 +24,7 @@ class SessionsController < ApplicationController
   end
 
   private
+
   def auth_params
     request.env['omniauth.auth']
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SessionsController < ApplicationController
+  skip_before_action :login_required
+
   def create
     user = User.find_or_create_from_auth_hash(auth_params)
     if user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,8 +2,29 @@
 
 class SessionsController < ApplicationController
   def create
-    user_data = request.env['omniauth.auth']
-    session[:nickname] = user_data[:info][:nickname]
-    redirect_to root_path, notice: 'ログインしました'
+    user = User.find_or_create_from_auth_hash(auth_params)
+    if user
+      log_in(user)
+      flash[:notice] = 'ログインしました'
+    else
+      flash[:notice] = '失敗しました'
+    end
+    redirect_to root_path
+  end
+
+  def destroy
+    log_out if logged_in?
+    flash[:notice] = 'ログアウトしました'
+    redirect_to root_path
+  end
+
+  def failure
+    flash[:notice] = 'キャンセルしました'
+    redirect_to root_path
+  end
+
+  private
+  def auth_params
+    request.env['omniauth.auth']
   end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class WelcomeController < ApplicationController
+  skip_before_action :login_required
+
   def index; end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -6,9 +6,7 @@ module SessionsHelper
   end
 
   def current_user
-    if session[:uid]
-      @current_user ||= User.find_by(uid: session[:uid])
-    end
+    @current_user ||= User.find_by(uid: session[:uid]) if session[:uid]
   end
 
   def logged_in?
@@ -17,6 +15,6 @@ module SessionsHelper
 
   def log_out
     session.delete(:uid)
-    @current_user = nil
+    @current_user = nil  # rubocop:disable Rails/HelperInstanceVariable
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module SessionsHelper
+  def log_in(user)
+    session[:uid] = user.uid
+  end
+
+  def current_user
+    if session[:uid]
+      @current_user ||= User.find_by(uid: session[:uid])
+    end
+  end
+
+  def logged_in?
+    !current_user.nil?
+  end
+
+  def log_out
+    session.delete(:uid)
+    @current_user = nil
+  end
+end

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -20,3 +20,24 @@ pre code {
     width: $code_block_width;
     border-radius: 4px;
 }
+
+.header-current-user-icon {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}
+.a-user-icon {
+    object-fit: cover;
+    border-radius: 50%;
+    background-color: white;
+}
+
+.index-title-items {
+    vertical-align: middle;
+}
+.index-title-item {
+    display: inline-block;
+    vertical-align: middle;
+    margin-left: auto;
+    margin-right: auto;
+}

--- a/app/models/code.rb
+++ b/app/models/code.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Code < ApplicationRecord
+  belongs_to :user
   has_one_attached :image
 
   enum language: {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :code
+
   def self.find_or_create_from_auth_hash(auth_hash)
     uid = auth_hash[:uid]
     twitter_id = auth_hash[:info][:nickname]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,15 @@
 class User < ApplicationRecord
+  def self.find_or_create_from_auth_hash(auth_hash)
+    uid = auth_hash[:uid]
+    twitter_id = auth_hash[:info][:nickname]
+    twitter_name = auth_hash[:info][:name]
+    twitter_icon = auth_hash[:info][:image]
+
+    find_or_create_by(uid: uid) do |user|
+      user.uid = uid
+      user.twitter_id = twitter_id
+      user.twitter_name = twitter_name
+      user.twitter_icon = twitter_icon
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class User < ApplicationRecord
-  has_many :code
+  has_many :code, dependent: :destroy
 
   def self.find_or_create_from_auth_hash(auth_hash)
     uid = auth_hash[:uid]

--- a/app/views/code/index.html.slim
+++ b/app/views/code/index.html.slim
@@ -2,16 +2,6 @@ section.hero
   .title.my-3
     |  一覧
 
-/ 確認用
-= link_to 'ログイン', "/auth/twitter", method: :post, class: "login"
-
-- if flash[:notice]
-  p
-    = flash[:notice]
-- if session[:nickname]
-  p
-    = "#{session[:nickname]}さん、こんにちは"
-
 .div
   - @code.each do |code|
     hr

--- a/app/views/code/index.html.slim
+++ b/app/views/code/index.html.slim
@@ -1,6 +1,9 @@
 section.hero
-  .title.my-3
-    |  一覧
+  .index-title-items
+    .index-title-item
+      = image_tag @user.twitter_icon, class: 'a-user-icon'
+    .title.my-3.index-title-item
+      = "#{@user.twitter_name}の投稿一覧"
 
 .div
   - @code.each do |code|

--- a/app/views/code/index.html.slim
+++ b/app/views/code/index.html.slim
@@ -2,6 +2,9 @@ section.hero
   .title.my-3
     |  一覧
 
+/ 確認用
+= link_to 'ログイン', "/auth/twitter", method: :post, class: "login"
+
 .div
   - @code.each do |code|
     hr

--- a/app/views/code/index.html.slim
+++ b/app/views/code/index.html.slim
@@ -5,6 +5,13 @@ section.hero
 / 確認用
 = link_to 'ログイン', "/auth/twitter", method: :post, class: "login"
 
+- if flash[:notice]
+  p
+    = flash[:notice]
+- if session[:nickname]
+  p
+    = "#{session[:nickname]}さん、こんにちは"
+
 .div
   - @code.each do |code|
     hr

--- a/app/views/code/show.html.slim
+++ b/app/views/code/show.html.slim
@@ -26,4 +26,4 @@ div
 div
   = link_to 'Destroy', @code, data: { confirm: 'Are you sure?' }, method: :delete, class: 'button is-light'
 div
-  = link_to 'Back', code_index_path, class: 'button is-light'
+  = link_to 'Back', user_code_index_path(@code.user.id), class: 'button is-light'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -16,7 +16,16 @@ html
       .navbar-end
         = link_to '新規作成', new_code_path, class: 'navbar-item'
         = link_to '投稿一覧', code_index_path, class: 'navbar-item'
-        = link_to 'ログイン', code_index_path, class: 'navbar-item'
+        - if logged_in?
+          = link_to 'ログアウト', logout_path, class: 'navbar-item'
+        - else
+          = link_to 'ログイン', '/auth/twitter', method: :post, class: 'navbar-item'
   body
     .container
+      - if flash[:notice]
+        p class="notification is-primary is-light"
+          = flash[:notice]
+      - if logged_in?
+        p
+          = "#{current_user.twitter_name}でログインしています"
       = yield

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -17,7 +17,12 @@ html
         - if logged_in?
           = link_to '新規作成', new_code_path, class: 'navbar-item'
           = link_to '投稿一覧', user_code_index_path(current_user.id), class: 'navbar-item'
-          = link_to 'ログアウト', logout_path, class: 'navbar-item'
+          .navbar-item.has-dropdown.is-hoverable
+            .navbar-link
+              .header-current-user-icon
+                = image_tag current_user.twitter_icon, class: 'a-user-icon'
+            .navbar-dropdown.is-right
+              = link_to 'ログアウト', logout_path, class: 'navbar-item'
         - else
           = link_to 'ログイン', '/auth/twitter', method: :post, class: 'navbar-item'
   body
@@ -25,7 +30,4 @@ html
       - if flash[:notice]
         p class="notification is-primary is-light"
           = flash[:notice]
-      - if logged_in?
-        p
-          = "#{current_user.twitter_name}でログインしています"
       = yield

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,9 +14,9 @@ html
       .navbar-brand
         = link_to 'ついこーど', root_path, class: 'navbar-item'
       .navbar-end
-        = link_to '新規作成', new_code_path, class: 'navbar-item'
-        = link_to '投稿一覧', code_index_path, class: 'navbar-item'
         - if logged_in?
+          = link_to '新規作成', new_code_path, class: 'navbar-item'
+          = link_to '投稿一覧', user_code_index_path(current_user.id), class: 'navbar-item'
           = link_to 'ログアウト', logout_path, class: 'navbar-item'
         - else
           = link_to 'ログイン', '/auth/twitter', method: :post, class: 'navbar-item'

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -12,4 +12,9 @@
     a href="https://twitter.com/yana_gis/status/1451100165985562632?ref_src=twsrc%5Etfw"  October 21, 2021
   script async="" charset="utf-8" src="https://platform.twitter.com/widgets.js"
 
-  = link_to 'ついこーどをつかってみる', new_code_path, class: 'button is-info my-5'
+  - if logged_in?
+    = link_to 'ついこーどをつかってみる', new_code_path, class: 'button is-info my-5'
+  - else
+    = link_to '/auth/twitter', method: :post, class: 'button is-info p-5 my-5' do
+      | ついこーどをつかってみる
+    p 利用にはTwitterログインが必要です

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,3 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :twitter, ENV['TWITTER_API_KEY'], ENV['TWITTER_API_SECRET']
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 Rails.application.routes.draw do
-  get 'welcome/index'
   root 'welcome#index'
-  get 'welcome', to: 'welcome#index', as: 'welcome'
-  resources :code, only: [:index, :show, :new, :create, :destroy]
+  resources :code, only: [:show, :new, :create, :destroy]
+  get 'users/:user_id/code', to: 'code#index', as: 'user_code_index'
 
+  get 'welcome', to: 'welcome#index', as: 'welcome'
   get '/auth/:provider/callback', to: 'sessions#create'
   get '/logout', to: 'sessions#destroy'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,5 @@ Rails.application.routes.draw do
   resources :code, only: [:index, :show, :new, :create, :destroy]
 
   get '/auth/:provider/callback', to: 'sessions#create'
-  # get '/logout', to: 'sessions#destroy'
+  get '/logout', to: 'sessions#destroy'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,7 @@ Rails.application.routes.draw do
   root 'welcome#index'
   get 'welcome', to: 'welcome#index', as: 'welcome'
   resources :code, only: [:index, :show, :new, :create, :destroy]
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  get '/auth/:provider/callback', to: 'sessions#create'
+  # get '/logout', to: 'sessions#destroy'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,6 @@ Rails.application.routes.draw do
 
   get 'welcome', to: 'welcome#index', as: 'welcome'
   get '/auth/:provider/callback', to: 'sessions#create'
+  get "/auth/failure", to: "sessions#failure"
   get '/logout', to: 'sessions#destroy'
 end

--- a/db/migrate/20211103023422_create_users.rb
+++ b/db/migrate/20211103023422_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :users do |t|
+      t.string :uid, null: false
+      t.string :twitter_id
+      t.string :twitter_name
+      t.string :twitter_icon
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211103061806_add_user_id_to_code.rb
+++ b/db/migrate/20211103061806_add_user_id_to_code.rb
@@ -1,0 +1,5 @@
+class AddUserIdToCode < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :code, :user, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,6 +48,8 @@ ActiveRecord::Schema.define(version: 2021_11_08_024536) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "language", default: 0, null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_code_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -61,4 +63,5 @@ ActiveRecord::Schema.define(version: 2021_11_08_024536) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "code", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,6 +50,15 @@ ActiveRecord::Schema.define(version: 2021_11_08_024536) do
     t.integer "language", default: 0, null: false
   end
 
+  create_table "users", force: :cascade do |t|
+    t.string "uid", null: false
+    t.string "twitter_id"
+    t.string "twitter_name"
+    t.string "twitter_icon"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    uid { "MyString" }
+    twitter_id { "MyString" }
+    twitter_name { "MyString" }
+    twitter_icon { "MyString" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :user do
-    uid { "MyString" }
-    twitter_id { "MyString" }
-    twitter_name { "MyString" }
-    twitter_icon { "MyString" }
+    uid { 'MyString' }
+    twitter_id { 'MyString' }
+    twitter_name { 'MyString' }
+    twitter_icon { 'MyString' }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe User, type: :model do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe User, type: :model do
       end
 
       it 'Userモデルのレコード件数が変化していないこと' do
-        expect { User.find_or_create_from_auth_hash(auth_hash) }.not_to change(User.count)
+        expect { User.find_or_create_from_auth_hash(auth_hash) }.not_to change(User, :count)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,5 +3,45 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '.find_or_create_from_auth_hash' do
+    let(:auth_hash) do
+      {
+        provider: 'twitter',
+        uid: 'uid',
+        info: {
+          nickname: 'twicode',
+          name: 'ついこーど',
+          image: 'http://example.com/twicode.jpg'
+        }
+      }
+    end
+
+    context 'uidに対応するUserが作成されていないとき' do
+      it '引数で設定した属性のUserオブジェクトが返ること' do
+        user = User.find_or_create_from_auth_hash(auth_hash)
+        expect(user.uid).to eq 'uid'
+        expect(user.twitter_id).to eq 'twicode'
+        expect(user.twitter_name).to eq 'ついこーど'
+        expect(user.twitter_icon).to eq 'http://example.com/twicode.jpg'
+        expect(user).to be_persisted
+      end
+
+      it 'Userモデルのレコードが一件増えていること' do
+        expect { User.find_or_create_from_auth_hash(auth_hash) }.to change { User.count }.from(0).to(1)
+      end
+    end
+
+    context 'uidに対応するUserが既に作成されているとき' do
+      let!(:created_user) { FactoryBot.create(:user, uid: 'uid') }
+
+      it '引数に対応するUserレコードのオブジェクトが返ること' do
+        user = User.find_or_create_from_auth_hash(auth_hash)
+        expect(user).to eq created_user
+      end
+
+      it 'Userモデルのレコード件数が変化していないこと' do
+        expect { User.find_or_create_from_auth_hash(auth_hash) }.not_to change(User.count)
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -63,4 +63,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include OmniauthMocks
 end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+OmniAuth.config.test_mode = true
+OmniAuth.config.on_failure = proc { |env| OmniAuth::FailureEndpoint.new(env).redirect_to_failure }

--- a/spec/support/omniauth_mocks.rb
+++ b/spec/support/omniauth_mocks.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module OmniauthMocks
-  def twitter_mock
+  def mock_twitter!
     OmniAuth.config.mock_auth[:twitter] =
       OmniAuth::AuthHash.new({
                                'provider' => 'twitter',
@@ -14,7 +14,7 @@ module OmniauthMocks
                              })
   end
 
-  def twitter_invalid_mock
+  def mock_twitter_failure!
     OmniAuth.config.mock_auth[:twitter] = :invalid_credentials
   end
 end

--- a/spec/support/omniauth_mocks.rb
+++ b/spec/support/omniauth_mocks.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module OmniauthMocks
+  def twitter_mock
+    OmniAuth.config.mock_auth[:twitter] =
+      OmniAuth::AuthHash.new({
+                               'provider' => 'twitter',
+                               'uid' => '123456',
+                               'info' => {
+                                 'nickname' => 'Mock User',
+                                 'name' => 'Mock User Name',
+                                 'image' => 'http://mock_image_url.com'
+                               }
+                             })
+  end
+
+  def twitter_invalid_mock
+    OmniAuth.config.mock_auth[:twitter] = :invalid_credentials
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Users', type: :system do
+  describe 'ログイン処理' do
+    describe 'ログイン状態' do
+      context 'ログインしていない場合' do
+        it 'ヘッダーにログインボタンが表示されること'
+        it 'ヘッダーのログインボタンを押すとTwitterのログイン画面に遷移されること'
+        it '新規登録画面に遷移するとログイン画面に遷移されること'
+      end
+      context 'ログインしている場合' do
+        it 'ヘッダーにログアウトボタンが表示されること'
+      end
+    end
+
+    describe 'Twitter認証' do
+      context '成功時' do
+        it '新規投稿画面に遷移すること'
+        it '成功した旨のメッセージが表示されること'
+        it 'user_idが取得できていること'
+      end
+      context '失敗時' do
+        it 'トップ画面に戻ること'
+        it '失敗した旨のメッセージが表示されること'
+      end
+      context '中断時' do
+        it 'トップ画面に戻ること'
+        it '中断した旨のメッセージが表示されること'
+      end
+    end
+  end
+
+  describe 'ログアウト処理' do
+    describe 'ログアウトができること' do
+      it 'ログアウトしましたと表示されること'
+      it 'ヘッダーにログインボタンが表示されること'
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -4,21 +4,20 @@ require 'rails_helper'
 
 RSpec.describe 'Users', type: :system do
   before do
-    OmniAuth.config.mock_auth[:twitter] = nil
+    twitter_mock
   end
 
   describe 'ログイン処理' do
-    context 'ログインボタンを押してTwitter認証を許可した時' do
+    context '認証が成功した時' do
       it 'ログインができる' do
-        Rails.application.env_config['omniauth.auth'] = twitter_mock
         visit root_path
         find_link('ログイン', href: '/auth/twitter').click
         expect(page).to have_content('ログインしました')
       end
     end
-    context 'ログインボタンを押してTwitter認証をキャンセルした時' do
+    context '認証が失敗した時' do
+      before { twitter_invalid_mock }
       it 'ログインができない' do
-        Rails.application.env_config['omniauth.auth'] = twitter_invalid_mock
         visit root_path
         find_link('ログイン', href: '/auth/twitter').click
         expect(page).to have_content('キャンセルしました')
@@ -28,7 +27,6 @@ RSpec.describe 'Users', type: :system do
 
   describe 'ログアウト処理' do
     before do
-      Rails.application.env_config['omniauth.auth'] = twitter_mock
       visit root_path
       find_link('ログイン', href: '/auth/twitter').click
     end
@@ -55,7 +53,6 @@ RSpec.describe 'Users', type: :system do
     end
     context 'ログインしている場合' do
       before do
-        Rails.application.env_config['omniauth.auth'] = twitter_mock
         visit root_path
         find_link('ログイン', href: '/auth/twitter').click
       end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -29,9 +29,10 @@ RSpec.describe 'Users', type: :system do
     before do
       visit root_path
       find_link('ログイン', href: '/auth/twitter').click
+      find_link('ログアウト', href: '/logout').click
     end
     it 'ログアウトができること' do
-      expect(page).to have_content('ログアウト')
+      expect(page).to have_content('ログアウトしました')
     end
   end
 

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -39,11 +39,17 @@ RSpec.describe 'Users', type: :system do
 
   describe 'ログイン状態による画面表示の確認' do
     context 'ログインしていない場合' do
-      before { visit root_path }
       it 'ヘッダーに新規作成・投稿一覧ボタンが表示されないこと' do
+        visit root_path
         within('nav') do
           expect(page).to_not have_content('新規作成')
           expect(page).to_not have_content('投稿一覧')
+        end
+      end
+      it 'code新規作成画面に遷移できず、代わりにwelcome画面に遷移すること' do
+        visit new_code_path
+        within('.title') do
+          expect(page).to have_content('ついこーど')
         end
       end
     end
@@ -57,6 +63,12 @@ RSpec.describe 'Users', type: :system do
         within('nav') do
           expect(page).to have_content('新規作成')
           expect(page).to have_content('投稿一覧')
+        end
+      end
+      it 'code新規作成画面に遷移できること' do
+        visit new_code_path
+        within('.title') do
+          expect(page).to have_content('新規作成')
         end
       end
     end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Users', type: :system do
   before do
-    twitter_mock
+    mock_twitter!
   end
 
   describe 'ログイン処理' do
@@ -16,7 +16,7 @@ RSpec.describe 'Users', type: :system do
       end
     end
     context '認証が失敗した時' do
-      before { twitter_invalid_mock }
+      before { mock_twitter_failure! }
       it 'ログインができない' do
         visit root_path
         find_link('ログイン', href: '/auth/twitter').click


### PR DESCRIPTION
close #29
close #26 

# 概要
- Twitter認証を使ってログインできるようにした
    - ログイン手段はTwitter認証のみ（deviseは使っていない）
- code一覧画面をユーザーごとに表示するようにした
- ログインしていない場合、code新規作成画面に遷移できないようにした

# 参考にしたリンク
- Twitterログイン
    - [Railsアプリに簡単なTwitterログインを実装する \- Qiita](https://qiita.com/d0ne1s/items/7a96b835280f55bb5234)
    - [第8章 基本的なログイン機構 \- Railsチュートリアル](https://railstutorial.jp/chapters/basic_login?version=5.1#sec-a_working_log_in_method)
- Omniauthのテスト
    - [\[Devise How\-To\] OmniAuth: 結合テスト（翻訳）｜TechRacho by BPS株式会社](https://techracho.bpsinc.jp/hachi8833/2017_05_22/40297)
    - [Mockを使って、Facebookログイン部分のRSpecを書いてみた！\! \| Clueit Developers Blog](https://www.wantedly.com/companies/clueit/post_articles/43708)

    - [【OmniAuth \+ Devise】Twitterのログイン認証をテストする方法【Rspec】 \- Qiita](https://qiita.com/ngron/items/88f04a2d864f9f33b389)

# タスク
- [x] Twitterでログインできるようにする
    - [x] 'dotenv-rails'導入
    - [x] omniauth-twitter 導入 
    - [x] User.rb作成
- [x] ルーティング設定
    - [x] 投稿一覧をユーザー別にする
    - [x] タイトル実装
- [x] ヘッダーのログインボタン実装
- [x] テスト
    - [x] モデルテスト
    - [x] システムテスト