### PR TITLE
Codeモデルにlanguage属性を追加・対応言語を増やした

### DIFF
--- a/app/controllers/code_controller.rb
+++ b/app/controllers/code_controller.rb
@@ -36,7 +36,7 @@ class CodeController < ApplicationController
   end
 
   def code_params
-    params.require(:code).permit(:body)
+    params.require(:code).permit(:body, :language)
   end
 
   def image_data_url

--- a/app/javascript/code/form.js
+++ b/app/javascript/code/form.js
@@ -9,6 +9,7 @@ document.addEventListener("turbolinks:load", () => {
   const hiddenImageDataUrl = document.querySelector("#code_image_data_url");
 
   if (precode) {
+    precode.className = language.innerHTML;
     hljs.highlightAll();
   }
   if (form) {

--- a/app/javascript/code/form.js
+++ b/app/javascript/code/form.js
@@ -12,7 +12,7 @@ document.addEventListener("turbolinks:load", () => {
     hljs.highlightAll();
   }
   if (form) {
-    precode.className = "ruby hljs language-ruby";
+    precode.className = "hljs language-PlainText";
 
     textarea.addEventListener("input", highlight);
     language.addEventListener("change", highlight);

--- a/app/models/code.rb
+++ b/app/models/code.rb
@@ -3,6 +3,36 @@
 class Code < ApplicationRecord
   has_one_attached :image
 
+  enum language: {
+    'PlainText': 0,
+    'Bash': 1,
+    'C': 2,
+    'C#': 3,
+    'C++': 4,
+    'CSS': 5,
+    'Diff': 6,
+    'Go': 7,
+    'HTML': 8,
+    'XML': 9,
+    'JSON': 10,
+    'Java': 11,
+    'JavaScript': 12,
+    'Kotlin': 13,
+    'Markdown': 14,
+    'PHP': 15,
+    'Perl': 16,
+    'Python': 17,
+    'R': 18,
+    'Ruby': 19,
+    'Rust': 20,
+    'SCSS': 21,
+    'SQL': 22,
+    'Shell': 23,
+    'Swift': 24,
+    'TypeScript': 25,
+    'YAML': 26
+  }
+
   def attach_blob(image_data_url)
     image_blob = ImageBlob.new(image_data_url)
     image.attach(

--- a/app/views/code/_form.html.slim
+++ b/app/views/code/_form.html.slim
@@ -10,13 +10,7 @@
       .label 言語
       .control
         .select
-          select#parse_language[name="parse[language]"]
-            option[value="ruby"]
-              | Ruby
-            option[value="javascript"]
-              | JavaScript
-            option[value="html"]
-              | HTML
+          = f.select :language, Code.languages.keys.to_a, {}, id: 'parse_language'
     .field
       .label コード
       .control

--- a/app/views/code/show.html.slim
+++ b/app/views/code/show.html.slim
@@ -6,13 +6,17 @@ section.hero
 p#notice = notice
 
 p
-  strong Body:
+  strong 言語:
+  p
+    = @code.language
+p
+  strong コード:
   pre
     code
       = @code.body
 - if @code.image.attached?
   p
-    strong image:
+    strong イメージ:
     p
       = image_tag @code.image
 

--- a/app/views/code/show.html.slim
+++ b/app/views/code/show.html.slim
@@ -7,7 +7,7 @@ p#notice = notice
 
 p
   strong 言語:
-  p
+  p#parse_language
     = @code.language
 p
   strong コード:

--- a/db/migrate/20211108024536_add_language_to_code.rb
+++ b/db/migrate/20211108024536_add_language_to_code.rb
@@ -1,0 +1,5 @@
+class AddLanguageToCode < ActiveRecord::Migration[6.1]
+  def change
+    add_column :code, :language, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_18_055147) do
+ActiveRecord::Schema.define(version: 2021_11_08_024536) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,12 +47,7 @@ ActiveRecord::Schema.define(version: 2021_10_18_055147) do
     t.text "body"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-  end
-
-  create_table "codes", force: :cascade do |t|
-    t.text "body"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.integer "language", default: 0, null: false
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
close #91, close #93 

- 新規作成画面で指定できる言語を増やした
    - 対応言語はhighlight.jsのCommon Packageに入っているもの
        - https://highlightjs.org/download/
- Codeモデルにlanguage属性を追加した
    - Codeモデルが言語情報を持っていないと、詳細画面で言語に合わせたシンタックスハイライトが適用できないため