### PR TITLE
bulma-tooltipライブラリの削除

### DIFF
--- a/app/javascript/styles/_1-modules.scss
+++ b/app/javascript/styles/_1-modules.scss
@@ -9,5 +9,3 @@
 @import "/node_modules/bulma/sass/helpers/all";
 @import "/node_modules/bulma/sass/layout/all";
 
-@import "/node_modules/@creativebulma/bulma-tooltip";
-

--- a/app/views/code/_form.html.slim
+++ b/app/views/code/_form.html.slim
@@ -26,8 +26,6 @@
     .field
       .label
         | Twitterで表示されるイメージ
-        span.icon.ml-1.has-tooltip-arrow[data-tooltip="画像からはみ出てしまったテキストは、Twitterで共有するURLから参照できます"]
-          i.fas.fa-info-circle
       .control
         pre
           code

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "webpack-cli": "^3.3.12"
       },
       "devDependencies": {
-        "@creativebulma/bulma-tooltip": "^1.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-config-standard": "^16.0.3",
@@ -1557,12 +1556,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@creativebulma/bulma-tooltip": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@creativebulma/bulma-tooltip/-/bulma-tooltip-1.2.0.tgz",
-      "integrity": "sha512-ooImbeXEBxf77cttbzA7X5rC5aAWm9UsXIGViFOnsqB+6M944GkB28S5R4UWRqjFd2iW4zGEkEifAU+q43pt2w==",
-      "dev": true
     },
     "node_modules/@csstools/convert-colors": {
       "version": "1.4.0",
@@ -13607,12 +13600,6 @@
         "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
       }
-    },
-    "@creativebulma/bulma-tooltip": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@creativebulma/bulma-tooltip/-/bulma-tooltip-1.2.0.tgz",
-      "integrity": "sha512-ooImbeXEBxf77cttbzA7X5rC5aAWm9UsXIGViFOnsqB+6M944GkB28S5R4UWRqjFd2iW4zGEkEifAU+q43pt2w==",
-      "dev": true
     },
     "@csstools/convert-colors": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "version": "0.1.0",
   "devDependencies": {
-    "@creativebulma/bulma-tooltip": "^1.2.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-standard": "^16.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,11 +887,6 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     "to-fast-properties" "^2.0.0"
 
-"@creativebulma/bulma-tooltip@^1.2.0":
-  "integrity" "sha512-ooImbeXEBxf77cttbzA7X5rC5aAWm9UsXIGViFOnsqB+6M944GkB28S5R4UWRqjFd2iW4zGEkEifAU+q43pt2w=="
-  "resolved" "https://registry.npmjs.org/@creativebulma/bulma-tooltip/-/bulma-tooltip-1.2.0.tgz"
-  "version" "1.2.0"
-
 "@csstools/convert-colors@^1.4.0":
   "integrity" "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
   "resolved" "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz"


### PR DESCRIPTION
CSSのライブラリbulma-tooltipが原因でherokuのデプロイ時に失敗するため削除で対応。
tooltipの表示はライブラリを使わずにCSSを書いて対応する予定。

```
           ERROR in ./app/javascript/packs/application.scss (./node_modules/css-loader/dist/cjs.js??ref--6-1!./node_modules/postcss-loader/src??ref--6-2!./node_modules/sass-loader/dist/cjs.js??ref--6-3!./node_modules/import-glob-loader!./app/javascript/packs/application.scss)
           Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
           SassError: Can't find stylesheet to import.
              ╷
           12 │ @import "/node_modules/@creativebulma/bulma-tooltip";
              │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
              ╵
             app/javascript/styles/_1-modules.scss 12:9  @import
             app/javascript/packs/application.scss 2:9   root stylesheet
```