### PR TITLE
デザインレビュー対応

### DIFF
--- a/app/controllers/code_controller.rb
+++ b/app/controllers/code_controller.rb
@@ -6,7 +6,7 @@ class CodeController < ApplicationController
 
   def index
     @user = User.find(params[:user_id] || current_user.id)
-    @code = @user.code.order(:created_at).page params[:page]
+    @code = @user.code.order(created_at: 'DESC').page params[:page]
   end
 
   def show

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class HomeController < ApplicationController
+  def top; end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class HomeController < ApplicationController
-  def top; end
+  def top
+    @code = current_user.code.order(:created_at).page params[:page]
+  end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,6 @@
 
 class HomeController < ApplicationController
   def top
-    @code = current_user.code.order(:created_at).page params[:page]
+    @code = current_user.code.order(created_at: 'DESC').page params[:page]
   end
 end

--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -7,10 +7,10 @@ module MetaTagsHelper
       site: 'TwiCode',
       reverse: true,
       charset: 'utf-8',
-      description: 'TwitterでCodeを共有しよう',
+      description: 'TwitterでちょっとしたCodeを共有しよう',
       viewport: 'width=device-width, initial-scale=1.0',
       og: {
-        title: :site,
+        title: page_twitter_title,
         type: 'website',
         site_name: 'TwiCode',
         description: :description,
@@ -18,9 +18,10 @@ module MetaTagsHelper
         url: 'https://twicode.herokuapp.com/'
       },
       twitter: {
+        title: page_twitter_title,
         card: 'summary_large_image',
         site: '@twicode_y',
-        description: page_twitter_title,
+        description: :description,
         image: page_twitter_image,
         domain: 'https://twicode.herokuapp.com/'
       }
@@ -33,6 +34,6 @@ module MetaTagsHelper
   end
 
   def page_twitter_title
-    @page_title || 'TwitterでCodeを共有しよう' # rubocop:disable Rails/HelperInstanceVariable
+    @page_title || 'TwiCode' # rubocop:disable Rails/HelperInstanceVariable
   end
 end

--- a/app/javascript/styles/_0-variables.scss
+++ b/app/javascript/styles/_0-variables.scss
@@ -8,10 +8,11 @@ $font-family-logo: 'Fredoka One', cursive;
 $family-sans-serif: 'ヒラギノ丸ゴ Pro W3', 'Hiragino Maru Gothic Pro', -apple-system, system-ui, 'Hiragino Sans', '游ゴシック  Medium', 'メイリオ',Meiryo, 'MS Pゴシック','MS PMGothic', sans-serif;
 
 // colors
+$primary: #88c0d0;
 $text: #4a4a4a;
 $text-strong: #4a4a4a;
 $link: #ebcb8b;
-$navbar-background-color: #88c0d0;
+$navbar-background-color: $primary;
 $navbar-item-hover-background-color: rgba(0, 0, 0, 0.05);
 $navbar-item-hover-color: #4a4a4a;
 $navbar-breakpoint: $tablet;

--- a/app/javascript/styles/_0-variables.scss
+++ b/app/javascript/styles/_0-variables.scss
@@ -11,7 +11,7 @@ $family-sans-serif: 'ヒラギノ丸ゴ Pro W3', 'Hiragino Maru Gothic Pro', -ap
 $primary: #88c0d0;
 $text: #4a4a4a;
 $text-strong: #4a4a4a;
-$link: #ebcb8b;
+$link: $primary;
 $navbar-background-color: $primary;
 $navbar-item-hover-background-color: rgba(0, 0, 0, 0.05);
 $navbar-item-hover-color: #4a4a4a;

--- a/app/javascript/styles/_body.scss
+++ b/app/javascript/styles/_body.scss
@@ -1,21 +1,25 @@
 @charset "utf-8";
 
-html {
-  height: 100%;
+body {
   background-color: #f5f5f5;
 }
 
-body {
-  height: 100%;
-}
-
-main {
-  min-height: 100%;
-  background-color: #ffffff;
-}
-
-.container {
+.wrapper {
+  margin: 0 auto;
   height: 100%;
   width: 700px;
   max-width: 100%;
+
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.wrapper__start {
+  background: #ffffff;
+  flex: 1;
+}
+
+.wrapper__end {
+  background: #ffffff;
 }

--- a/app/javascript/styles/_body.scss
+++ b/app/javascript/styles/_body.scss
@@ -3,9 +3,6 @@
 html {
   height: 100%;
   background-color: #f5f5f5;
-  &.background-color-is-primary {
-    background-color: #88c0d0;
-  }
 }
 
 body {

--- a/app/javascript/styles/_body.scss
+++ b/app/javascript/styles/_body.scss
@@ -3,6 +3,9 @@
 html {
   height: 100%;
   background-color: #f5f5f5;
+  &.background-color-is-primary {
+    background-color: #88c0d0;
+  }
 }
 
 body {

--- a/app/javascript/styles/_code.scss
+++ b/app/javascript/styles/_code.scss
@@ -44,4 +44,10 @@ pre code {
       vertical-align: middle;
     }
   }
+  .icon-text {
+    align-items: center;
+  }
+  .code-meta-item {
+    margin: 0.25rem;
+  }
 }

--- a/app/javascript/styles/_code.scss
+++ b/app/javascript/styles/_code.scss
@@ -37,7 +37,7 @@ pre code {
   }
 }
 
-.index-code {
+.show-code, .index-code {
   .icon-text {
     align-items: center;
   }

--- a/app/javascript/styles/_code.scss
+++ b/app/javascript/styles/_code.scss
@@ -32,8 +32,8 @@ pre code {
   }
 
   .code-item {
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
   }
 }
 

--- a/app/javascript/styles/_code.scss
+++ b/app/javascript/styles/_code.scss
@@ -38,12 +38,6 @@ pre code {
 }
 
 .index-code {
-  .page-title {
-    img, h1{
-      display: inline-block;
-      vertical-align: middle;
-    }
-  }
   .icon-text {
     align-items: center;
   }

--- a/app/javascript/styles/_common.scss
+++ b/app/javascript/styles/_common.scss
@@ -64,5 +64,7 @@
 .notification {
   border-radius: 9999px;
   padding: 1.25rem 2.5rem 1.25rem 2.5rem;
+  &.is-primary, &.is-primary.is-light{
   color: #4a4a4a;
+  }
 }

--- a/app/javascript/styles/_common.scss
+++ b/app/javascript/styles/_common.scss
@@ -9,7 +9,7 @@
 }
 .pagination-link.is-current {
   &:hover {
-    background-color: #ebcb8b;
+    background-color: $primary;
   }
 }
 @media screen and (min-width: 769px), print {

--- a/app/javascript/styles/_common.scss
+++ b/app/javascript/styles/_common.scss
@@ -35,6 +35,23 @@
   }
 }
 
+.button {
+  border-radius: 9999px;
+}
+
 .box {
   padding: 0.25rem;
+}
+
+.card {
+  border-radius: 16px;
+  .card-image {
+    margin: 1em;
+  }
+}
+
+.notification {
+  border-radius: 9999px;
+  padding: 1.25rem 2.5rem 1.25rem 2.5rem;
+  color: #4a4a4a;
 }

--- a/app/javascript/styles/_common.scss
+++ b/app/javascript/styles/_common.scss
@@ -37,7 +37,7 @@
 
 .button {
   border-radius: 9999px;
-  padding: 0 5em;
+  padding: 0 2em;
   &.is-primary, &.is-primary:hover {
     color: #4a4a4a;
   }
@@ -53,6 +53,9 @@
 
 .card {
   border-radius: 16px;
+  box-shadow: initial;
+  margin: 0 5rem;
+  padding: 0.15rem;
   .card-image {
     margin: 1em;
   }

--- a/app/javascript/styles/_common.scss
+++ b/app/javascript/styles/_common.scss
@@ -37,6 +37,14 @@
 
 .button {
   border-radius: 9999px;
+  padding: 0 5em;
+  &.is-primary, &.is-primary:hover {
+    color: #4a4a4a;
+  }
+  &.is-black {
+    color: #ffffff;
+    background-color: #4a4a4a;
+  }
 }
 
 .box {

--- a/app/javascript/styles/_footer.scss
+++ b/app/javascript/styles/_footer.scss
@@ -1,7 +1,6 @@
 @charset "utf-8";
 
 footer {
-  background-color: #ffffff;
   padding: 1rem;
 
   a {

--- a/app/javascript/styles/_footer.scss
+++ b/app/javascript/styles/_footer.scss
@@ -9,7 +9,7 @@ footer {
   }
 
   a:hover {
-    color: #ebcb8b;
+    color: $primary;
   }
 
   .social-link {

--- a/app/javascript/styles/_welcome.scss
+++ b/app/javascript/styles/_welcome.scss
@@ -8,14 +8,9 @@
   font-family: $font-family-logo;
 }
 
-main {
-  &.welcome-page {
-    min-height: initial;
+body, .wrapper__start, .wrapper__end {
+  &.is-welcome {
+    background: #88c0d0;
   }
 }
 
-html, main, footer {
-  &.welcome-page {
-    background-color: #88c0d0;
-  }
-}

--- a/app/javascript/styles/_welcome.scss
+++ b/app/javascript/styles/_welcome.scss
@@ -7,3 +7,15 @@
 .welcome-title {
   font-family: $font-family-logo;
 }
+
+main {
+  &.welcome-page {
+    min-height: initial;
+  }
+}
+
+html, main, footer {
+  &.welcome-page {
+    background-color: #88c0d0;
+  }
+}

--- a/app/javascript/styles/_welcome.scss
+++ b/app/javascript/styles/_welcome.scss
@@ -3,3 +3,7 @@
     padding: 0.75rem 0;
   }
 }
+
+.welcome-title {
+  font-family: $font-family-logo;
+}

--- a/app/models/code.rb
+++ b/app/models/code.rb
@@ -17,7 +17,7 @@ class Code < ApplicationRecord
   end
 
   def self.default_title
-    "Code of #{(Time.zone.today).strftime('%Y/%m/%d')}"
+    'Untitled'
   end
 
   def attach_blob(image_data_url)

--- a/app/views/code/_code_list.html.slim
+++ b/app/views/code/_code_list.html.slim
@@ -1,0 +1,18 @@
+.mb-3
+  = paginate code_list
+.div
+  - code_list.each do |code|
+    hr
+    div
+      .my-1
+        span.icon.mr-1
+          i.fas.fa-pen
+        span
+          = code.title
+      div
+        = link_to code, class: 'code-image' do
+          = image_tag(code.image)
+      div
+        = l code.created_at, format: :long
+.mb-3
+  = paginate code_list

--- a/app/views/code/_code_list.html.slim
+++ b/app/views/code/_code_list.html.slim
@@ -1,6 +1,6 @@
 .mb-3
   = paginate code_list
-- if (code_list.length.zero?)
+- if code_list.length.zero?
   .has-text-centered.has-text-grey
     .is-size-1
       i.far.fa-sad-tear

--- a/app/views/code/_code_list.html.slim
+++ b/app/views/code/_code_list.html.slim
@@ -3,16 +3,23 @@
 .div
   - code_list.each do |code|
     hr
-    div
-      .my-1
-        span.icon.mr-1
-          i.fas.fa-pen
-        span
-          = code.title
-      div
-        = link_to code, class: 'code-image' do
-          = image_tag(code.image)
-      div
-        = l code.created_at, format: :long
+      .columns.is-vcentered
+        .column.is-three-fifths
+          = link_to code, class: 'code-image' do
+            = image_tag(code.image)
+        .column.code-meta-items
+          .code-meta-item.is-size-5
+            = code.title
+          .code-meta-item.icon-text.is-size-7.has-text-grey
+            span.icon
+              i.fas.fa-code
+            span
+              = code.language.name
+          .code-meta-item.is-size-7.has-text-grey
+            span.mr-2
+              | 投稿日:
+            span
+              = l code.created_at, format: :long
+hr
 .mb-3
   = paginate code_list

--- a/app/views/code/_code_list.html.slim
+++ b/app/views/code/_code_list.html.slim
@@ -1,8 +1,14 @@
 .mb-3
   = paginate code_list
-.div
-  - code_list.each do |code|
-    hr
+- if (code_list.length.zero?)
+  .has-text-centered.has-text-grey
+    .is-size-1
+      i.far.fa-sad-tear
+    .o-empty-message__text
+      | 投稿はまだありません
+- else
+  div
+    - code_list.each do |code|
       .columns.is-vcentered
         .column.is-three-fifths
           = link_to code, class: 'code-image' do
@@ -20,6 +26,6 @@
               | 投稿日:
             span
               = l code.created_at, format: :long
-hr
+      hr
 .mb-3
   = paginate code_list

--- a/app/views/code/_code_list.html.slim
+++ b/app/views/code/_code_list.html.slim
@@ -14,13 +14,13 @@
           = link_to code, class: 'code-image' do
             = image_tag(code.image)
         .column.code-meta-items
-          .code-meta-item.is-size-5
-            = code.title
           .code-meta-item.icon-text.is-size-7.has-text-grey
             span.icon
               i.fas.fa-code
             span
               = code.language.name
+          .code-meta-item.is-size-5
+            = code.title
           .code-meta-item.is-size-7.has-text-grey
             span.mr-2
               | 投稿日:

--- a/app/views/code/_form.html.slim
+++ b/app/views/code/_form.html.slim
@@ -32,8 +32,9 @@
     .field
       .control
         = f.hidden_field :image_data_url, value: ''
+    hr
     .field
       .control
-      .actions = f.submit '画像を作成する', class: "button is-primary"
-      p.has-text-grey.is-size-7.my-1
+      .actions = f.submit '画像を作成する', class: "button is-primary has-text-weight-bold px-6"
+      p.is-size-7.my-5
         | Twitterに共有するURLに遷移します (まだTweetはしません)

--- a/app/views/code/_form.html.slim
+++ b/app/views/code/_form.html.slim
@@ -10,12 +10,10 @@
       .control
         = f.text_area :body, placeholder: 'Input your code.', class: 'textarea'
     .columns
-      .column
+      .column.is-two-thirds
         .field
-          .control.has-icons-left
+          .control
             = f.text_field :title, placeholder: Code.default_title, class: 'input'
-            .icon.is-small.is-left
-              i.fas.fa-pen
       .column
         .field
           .control.has-icons-left

--- a/app/views/code/_form.html.slim
+++ b/app/views/code/_form.html.slim
@@ -34,6 +34,6 @@
         = f.hidden_field :image_data_url, value: ''
     .field
       .control
-      .actions = f.submit '画像を作成する', class: "button is-light'"
+      .actions = f.submit '画像を作成する', class: "button is-primary"
       p.has-text-grey.is-size-7.my-1
         | Twitterに共有するURLに遷移します (まだTweetはしません)

--- a/app/views/code/_form.html.slim
+++ b/app/views/code/_form.html.slim
@@ -6,6 +6,9 @@
         ul
           - @code.errors.full_messages.each do |message|
             li = message
+    .field
+      .control
+        = f.text_area :body, placeholder: 'Input your code.', class: 'textarea'
     .columns
       .column
         .field
@@ -20,9 +23,6 @@
               = f.collection_select :language, Language.all.order(:name), :name, :name, { selected: @selected_language }
             .icon.is-small.is-left
               i.fas.fa-code
-    .field
-      .control
-        = f.text_area :body, placeholder: 'Input your code.', class: 'textarea'
     .field
       .label
         | Twitterで表示されるイメージ

--- a/app/views/code/_form.html.slim
+++ b/app/views/code/_form.html.slim
@@ -1,7 +1,7 @@
 .code-block
   = form_with scope: :code, url: code_index_path do |f|
     - if @code.errors.any?
-      .notification.is-warning.is-light
+      .notification.is-primary.is-light
         h2 = 'エラーが発生しました'
         ul
           - @code.errors.full_messages.each do |message|

--- a/app/views/code/_form.html.slim
+++ b/app/views/code/_form.html.slim
@@ -33,6 +33,6 @@
     hr
     .field
       .control
-      .actions = f.submit '画像を作成する', class: "button is-primary has-text-weight-bold px-6"
+      .actions = f.submit '画像を作成する', class: 'button is-primary has-text-weight-bold px-6'
       p.is-size-7.my-5
         | Twitterに共有するURLに遷移します (まだTweetはしません)

--- a/app/views/code/index.html.slim
+++ b/app/views/code/index.html.slim
@@ -1,6 +1,8 @@
 .index-code
-  .page-title
-    h1
-      = image_tag @user.twitter_icon, class: 'a-user-icon m-1'
-      = "#{@user.twitter_id}の投稿一覧"
+  h1
+    .icon-text
+      span.icon.is-large.mr-2
+        = image_tag @user.twitter_icon, class: 'a-user-icon m-1'
+      span.is-size-5
+        = "#{@user.twitter_id}の投稿一覧"
   == render 'code_list', code_list: @code

--- a/app/views/code/index.html.slim
+++ b/app/views/code/index.html.slim
@@ -1,3 +1,5 @@
+- content_for(:html_title) { "#{@user.twitter_id} の投稿一覧" }
+
 .index-code
   h1
     .icon-text

--- a/app/views/code/index.html.slim
+++ b/app/views/code/index.html.slim
@@ -3,21 +3,4 @@
     h1
       = image_tag @user.twitter_icon, class: 'a-user-icon m-1'
       = "#{@user.twitter_id}の投稿一覧"
-  .mb-3
-    = paginate @code
-  .div
-    - @code.each do |code|
-      hr
-      div
-        .my-1
-          span.icon.mr-1
-            i.fas.fa-pen
-          span
-            = code.title
-        div
-          = link_to code, class: 'code-image' do
-            = image_tag(code.image)
-        div
-          = l code.created_at, format: :long
-  .mb-3
-    = paginate @code
+  == render 'code_list', code_list: @code

--- a/app/views/code/new.html.slim
+++ b/app/views/code/new.html.slim
@@ -1,6 +1,6 @@
 .page-title
   h1
-    |  新規作成
+    |  コードの画像を作成
 
 .new-code
   == render 'form'

--- a/app/views/code/new.html.slim
+++ b/app/views/code/new.html.slim
@@ -1,3 +1,5 @@
+- content_for(:html_title) { 'コードの画像を作成' }
+
 .page-title
   h1
     |  コードの画像を作成

--- a/app/views/code/show.html.slim
+++ b/app/views/code/show.html.slim
@@ -28,17 +28,20 @@
         span
           = l @code.created_at, format: :long
   .code-item
+    = link_to @tweet_url, class: 'button is-primary px-6', target: 'blank' do
+      span.icon
+        i.fab.fa-twitter
+      span
+        | この画像をTweetする
+    p.is-size-7.my-5
+      | Twitterの投稿画面に遷移します
+  hr
+  .code-item
+    h2.is-size-5.my-5
+      | 元のコード
     pre
       code
         = @code.body
   .code-item
-    = link_to @tweet_url, class: 'button is-primary', target: 'blank' do
-      span.icon
-        i.fab.fa-twitter
-      span
-        | Tweetする
-    p.has-text-grey.is-size-7
-      | Twitterの投稿画面に遷移します
-  .code-item.has-text-right
     - if current_user == @code.user
-      = link_to '削除', @code, data: { confirm: '削除しますか?' }, method: :delete, class: 'button is-light'
+      = link_to '削除する', @code, data: { confirm: '削除しますか?' }, method: :delete, class: 'button is-light'

--- a/app/views/code/show.html.slim
+++ b/app/views/code/show.html.slim
@@ -1,5 +1,5 @@
 - @page_image = polymorphic_url(@code.image)
-- @page_title = @code.title
+- @page_title = "#{@code.title} (#{@code.language.name}) | TwiCode"
 
 .show-code
   .columns.is-vcentered

--- a/app/views/code/show.html.slim
+++ b/app/views/code/show.html.slim
@@ -36,7 +36,7 @@
       p.code-image
         = image_tag @code.image, id: 'code-image'
   .code-item
-    = link_to @tweet_url, class: 'button is-info', target: 'blank' do
+    = link_to @tweet_url, class: 'button is-primary', target: 'blank' do
       span.icon
         i.fab.fa-twitter
       span

--- a/app/views/code/show.html.slim
+++ b/app/views/code/show.html.slim
@@ -1,4 +1,4 @@
-- content_for(:html_title) { "#{@code.title}" }
+- content_for(:html_title) { @code.title.to_s }
 - @page_image = polymorphic_url(@code.image)
 - @page_title = "#{@code.title} (#{@code.language.name}) | TwiCode"
 

--- a/app/views/code/show.html.slim
+++ b/app/views/code/show.html.slim
@@ -2,39 +2,35 @@
 - @page_title = @code.title
 
 .show-code
-  .page-title
-    h1
-      |  詳細画面
-    .page-header-items
-      .page-header-item
-        = image_tag @code.user.twitter_icon, class: 'a-user-icon'
-      .page-header-item
-        div
-          = link_to user_code_index_path(@code.user.id), class: 'user-code-index-link has-text-weight-medium is-size-5' do
+  .columns.is-vcentered
+    .column.is-three-fifths
+      - if @code.image.attached?
+        p.code-image
+          = image_tag @code.image, id: 'code-image'
+    .column.code-meta-items
+      h1
+        .code-meta-item.is-size-5
+          = @code.title
+      .code-meta-item.icon-text
+        span.icon.is-medium.mr-2
+          = image_tag @code.user.twitter_icon, class: 'a-user-icon'
+        span
+          = link_to user_code_index_path(@code.user.id), class: 'user-code-index-link has-text-weight-bold' do
             = @code.user.twitter_id
-        .has-text-grey
-          div
-            = "投稿日: #{l @code.created_at, format: :long}"
-  .code-item
-    span.icon.mr-2
-      i.fas.fa-pen
-    span
-      = @code.title
-  .code-item
-    span.icon.mr-2
-      i.fas.fa-code
-    span#code_language
-      = @code.language.name
+      .code-meta-item.icon-text
+        span.icon
+          i.fas.fa-code
+        span#code_language
+          = @code.language.name
+      .code-meta-item.is-size-7.has-text-grey
+        span.mr-2
+          | 投稿日:
+        span
+          = l @code.created_at, format: :long
   .code-item
     pre
       code
         = @code.body
-  .code-item
-  - if @code.image.attached?
-    p
-      | Twitterで表示される画像
-      p.code-image
-        = image_tag @code.image, id: 'code-image'
   .code-item
     = link_to @tweet_url, class: 'button is-primary', target: 'blank' do
       span.icon

--- a/app/views/code/show.html.slim
+++ b/app/views/code/show.html.slim
@@ -28,7 +28,7 @@
         span
           = l @code.created_at, format: :long
   .code-item
-    = link_to @tweet_url, class: 'button is-primary px-6', target: 'blank' do
+    = link_to @tweet_url, class: 'button is-primary has-text-weight-bold px-6', target: 'blank' do
       span.icon
         i.fab.fa-twitter
       span

--- a/app/views/code/show.html.slim
+++ b/app/views/code/show.html.slim
@@ -1,3 +1,4 @@
+- content_for(:html_title) { "#{@code.title}" }
 - @page_image = polymorphic_url(@code.image)
 - @page_title = "#{@code.title} (#{@code.language.name}) | TwiCode"
 

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -1,0 +1,2 @@
+h1 Home#top
+p Find me in app/views/home/top.html.slim

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -1,3 +1,5 @@
+- content_for(:html_title) { '自分の投稿一覧' }
+
 .index-code
   .has-text-centered
     = link_to new_code_path, class: 'button is-black has-text-weight-bold' do

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -1,2 +1,9 @@
 .index-code
+  .has-text-centered
+    = link_to new_code_path, class: 'button is-black has-text-weight-bold' do
+      span.icon
+        i.fas.fa-plus
+      span
+        | 新しくコードを投稿する
+  hr
   == render 'code/code_list', code_list: @code

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -1,2 +1,2 @@
-h1 Home#top
-p Find me in app/views/home/top.html.slim
+.index-code
+  == render 'code/code_list', code_list: @code

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -8,3 +8,4 @@
           == page_tag page
       == next_page_tag unless current_page.last?
       == last_page_tag unless current_page.last?
+  hr

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,4 +1,6 @@
 doctype html
+/ turbolinksをオフにしたら書き換える
+/html class="#{current_page?(welcome_path) ? 'background-color-is-primary' : ''}"
 html
   head
     title
@@ -14,10 +16,13 @@ html
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body
     .container
-      = render "shared/header"
-      main.p-5
-        - if flash[:notice]
-          p class="notification is-primary is-light"
-            = flash[:notice]
+      - if current_page?(welcome_path)
         = yield
-      = render "shared/footer"
+      - else
+        = render "shared/header"
+        main.p-5
+          - if flash[:notice]
+            p class="notification is-primary is-light"
+              = flash[:notice]
+          = yield
+        = render "shared/footer"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html class="#{current_page?(welcome_path) ? 'welcome-page' : ''}"
+html
   head
     title
       = content_for?(:html_title) ? "TwiCode - #{yield(:html_title)}" : "TwiCode"
@@ -12,13 +12,15 @@ html class="#{current_page?(welcome_path) ? 'welcome-page' : ''}"
     = favicon_link_tag('/favicon.ico')
     = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
-  body
-    .container
-      - unless current_page?(welcome_path)
-        = render "shared/header"
-      main class="p-5 #{current_page?(welcome_path) ? 'welcome-page' : ''}"
-        - if flash[:notice]
-          p class="notification is-primary #{current_page?(welcome_path) ? 'has-text-centered' : 'is-light'}"
-            = flash[:notice]
-        = yield
-      = render "shared/footer"
+  body class="#{current_page?(welcome_path) ? 'is-welcome' : ''}"
+    .wrapper
+      .wrapper__start class="#{current_page?(welcome_path) ? 'is-welcome' : ''}"
+        - unless current_page?(welcome_path)
+          = render "shared/header"
+        main.p-5
+          - if flash[:notice]
+            p class="notification is-primary #{current_page?(welcome_path) ? 'has-text-centered' : 'is-light'}"
+              = flash[:notice]
+          = yield
+      .wrapper__end class="#{current_page?(welcome_path) ? 'is-welcome' : ''}"
+        = render "shared/footer"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -2,7 +2,7 @@ doctype html
 html
   head
     title
-      = content_for?(:html_title) ? "TwiCode - #{yield(:html_title)}" : "TwiCode"
+      = content_for?(:html_title) ? "TwiCode - #{yield(:html_title)}" : 'TwiCode'
     link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.2.0/styles/nord.min.css"
     link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.10.0/css/all.css"
     meta[name="viewport" content="width=device-width,initial-scale=1"]
@@ -16,11 +16,11 @@ html
     .wrapper
       .wrapper__start class="#{current_page?(welcome_path) ? 'is-welcome' : ''}"
         - unless current_page?(welcome_path)
-          = render "shared/header"
+          = render 'shared/header'
         main.p-5
           - if flash[:notice]
             p class="notification is-primary #{current_page?(welcome_path) ? 'has-text-centered' : 'is-light'}"
               = flash[:notice]
           = yield
       .wrapper__end class="#{current_page?(welcome_path) ? 'is-welcome' : ''}"
-        = render "shared/footer"
+        = render 'shared/footer'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -2,7 +2,7 @@ doctype html
 html class="#{current_page?(welcome_path) ? 'welcome-page' : ''}"
   head
     title
-      | TwiCode
+      = content_for?(:html_title) ? "TwiCode - #{yield(:html_title)}" : "TwiCode"
     link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.2.0/styles/nord.min.css"
     link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.10.0/css/all.css"
     meta[name="viewport" content="width=device-width,initial-scale=1"]

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -18,7 +18,7 @@ html class="#{current_page?(welcome_path) ? 'welcome-page' : ''}"
         = render "shared/header"
       main class="p-5 #{current_page?(welcome_path) ? 'welcome-page' : ''}"
         - if flash[:notice]
-          p class="notification is-primary is-light"
+          p class="notification is-primary #{current_page?(welcome_path) ? 'has-text-centered' : 'is-light'}"
             = flash[:notice]
         = yield
       = render "shared/footer"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,7 +1,5 @@
 doctype html
-/ turbolinksをオフにしたら書き換える
-/html class="#{current_page?(welcome_path) ? 'background-color-is-primary' : ''}"
-html
+html class="#{current_page?(welcome_path) ? 'welcome-page' : ''}"
   head
     title
       | TwiCode
@@ -16,13 +14,11 @@ html
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body
     .container
-      - if current_page?(welcome_path)
-        = yield
-      - else
+      - unless current_page?(welcome_path)
         = render "shared/header"
-        main.p-5
-          - if flash[:notice]
-            p class="notification is-primary is-light"
-              = flash[:notice]
-          = yield
-        = render "shared/footer"
+      main class="p-5 #{current_page?(welcome_path) ? 'welcome-page' : ''}"
+        - if flash[:notice]
+          p class="notification is-primary is-light"
+            = flash[:notice]
+        = yield
+      = render "shared/footer"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,40 +14,10 @@ html
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body
     .container
-      header
-        nav.navbar
-          .navbar-brand
-            = link_to '</ TwiCode >', root_path, class: 'navbar-item header_title'
-            .navbar-burger[data-target="navbarExampleTransparentExample"]
-              span
-              span
-              span
-          .navbar-menu#navbarExampleTransparentExample
-            .navbar-end
-              - if logged_in?
-                = link_to '新規作成', new_code_path, class: 'navbar-item has-text-weight-bold'
-                = link_to '投稿一覧', user_code_index_path(current_user.id), class: 'navbar-item has-text-weight-bold'
-                .navbar-item.has-dropdown.is-hoverable
-                  .navbar-link
-                    .current-user-icon
-                      = image_tag current_user.twitter_icon, class: 'a-user-icon'
-                  .navbar-dropdown.is-right
-                    = link_to 'ログアウト', logout_path, class: 'navbar-item'
-              - else
-                = link_to 'ログイン', '/auth/twitter', method: :post, class: 'navbar-item'
+      = render "shared/header"
       main.p-5
         - if flash[:notice]
           p class="notification is-primary is-light"
             = flash[:notice]
         = yield
-      footer
-        .has-text-centered
-          = link_to 'https://github.com/yana-gi/twicode', class: 'social-link' do
-            i.fab.fa-github
-          = link_to 'https://github.com/yana-gi/twicode', class: 'social-link' do
-            i.fab.fa-twitter
-          = link_to '利用規約', tos_path, class: 'mx-3'
-          = link_to 'プライバシーポリシー', privacy_policy_path, class: 'mx-3'
-          div
-            = Time.current.year
-            |  ©yana-gi
+      = render "shared/footer"

--- a/app/views/shared/_footer.html.slim
+++ b/app/views/shared/_footer.html.slim
@@ -1,4 +1,4 @@
-footer
+footer class="#{current_page?(welcome_path) ? 'welcome-page' : ''}"
   .has-text-centered
     = link_to 'https://github.com/yana-gi/twicode', class: 'social-link' do
       i.fab.fa-github

--- a/app/views/shared/_footer.html.slim
+++ b/app/views/shared/_footer.html.slim
@@ -1,4 +1,4 @@
-footer class="#{current_page?(welcome_path) ? 'welcome-page' : ''}"
+footer
   .has-text-centered
     = link_to 'https://github.com/yana-gi/twicode', class: 'social-link' do
       i.fab.fa-github

--- a/app/views/shared/_footer.html.slim
+++ b/app/views/shared/_footer.html.slim
@@ -1,0 +1,11 @@
+footer
+  .has-text-centered
+    = link_to 'https://github.com/yana-gi/twicode', class: 'social-link' do
+      i.fab.fa-github
+    = link_to 'https://github.com/yana-gi/twicode', class: 'social-link' do
+      i.fab.fa-twitter
+    = link_to '利用規約', tos_path, class: 'mx-3'
+    = link_to 'プライバシーポリシー', privacy_policy_path, class: 'mx-3'
+    div
+      = Time.current.year
+      |  ©yana-gi

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -9,13 +9,23 @@ header
     .navbar-menu#navbarExampleTransparentExample
       .navbar-end
         - if logged_in?
-          = link_to '新規作成', new_code_path, class: 'navbar-item has-text-weight-bold'
-          = link_to '投稿一覧', user_code_index_path(current_user.id), class: 'navbar-item has-text-weight-bold'
-          .navbar-item.has-dropdown.is-hoverable
-            .navbar-link
-              .current-user-icon
-                = image_tag current_user.twitter_icon, class: 'a-user-icon'
-            .navbar-dropdown.is-right
-              = link_to 'ログアウト', logout_path, class: 'navbar-item'
+          - unless current_page?(root_path)
+            .navbar-item
+              = link_to new_code_path, class: 'button is-black is-small is-rounded has-text-weight-bold' do
+                span.icon
+                  i.fas.fa-plus
+                span
+                  | 新しくコードを投稿する
+          .navbar-item
+            .current-user-icon
+              = image_tag current_user.twitter_icon, class: 'a-user-icon'
+          = link_to logout_path, class: 'navbar-item' do
+            span.icon.is-medium
+              i.fas.fa-sign-out-alt
         - else
-          = link_to 'ログイン', '/auth/twitter', method: :post, class: 'navbar-item'
+          .navbar-item
+            = link_to new_code_path, class: 'button is-black is-small is-rounded has-text-weight-bold' do
+              span.icon
+                i.fas.fa-plus
+              span
+                | 新しくコードを投稿する

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,0 +1,21 @@
+header
+  nav.navbar
+    .navbar-brand
+      = link_to '</ TwiCode >', root_path, class: 'navbar-item header_title'
+      .navbar-burger[data-target="navbarExampleTransparentExample"]
+        span
+        span
+        span
+    .navbar-menu#navbarExampleTransparentExample
+      .navbar-end
+        - if logged_in?
+          = link_to '新規作成', new_code_path, class: 'navbar-item has-text-weight-bold'
+          = link_to '投稿一覧', user_code_index_path(current_user.id), class: 'navbar-item has-text-weight-bold'
+          .navbar-item.has-dropdown.is-hoverable
+            .navbar-link
+              .current-user-icon
+                = image_tag current_user.twitter_icon, class: 'a-user-icon'
+            .navbar-dropdown.is-right
+              = link_to 'ログアウト', logout_path, class: 'navbar-item'
+        - else
+          = link_to 'ログイン', '/auth/twitter', method: :post, class: 'navbar-item'

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -19,7 +19,7 @@ header
           .navbar-item
             .current-user-icon
               = image_tag current_user.twitter_icon, class: 'a-user-icon'
-          = link_to logout_path, class: 'navbar-item' do
+          = link_to logout_path, class: 'navbar-item logout-link' do
             span.icon.is-medium
               i.fas.fa-sign-out-alt
         - else

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -1,6 +1,6 @@
 .welcome
   .welcome-items.has-text-centered
-    .welcome-item.mt-6
+    .welcome-item.mt-3
       h1.welcome-title.is-size-1
         | &lt;/
         |  TwiCode

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -1,66 +1,26 @@
-.welcome-items.has-text-centered
-  .welcome-item
-    h1.is-size-5.has-text-weight-bold
-      | TwitterでちょっとしたCodeを共有できるサービス
-  .welcome-item
-    .card.m-4
-      .card-image
-        = image_pack_tag 'top_1.png'
-  - if logged_in?
+.welcome
+  .welcome-items.has-text-centered
+    .welcome-item.mt-6
+      h1.welcome-title.is-size-1
+        | &lt;/
+        |  TwiCode
+        |  &gt;
+      h2.is-size-5.has-text-weight-bold
+        | ついこーど
     .welcome-item
-      = link_to 'TwiCode を使ってみる', new_code_path, class: 'button is-black has-text-weight-bold py-3'
-  - else
+      .card
+        .card-image
+          = image_pack_tag 'top_1.png'
     .welcome-item
-      = link_to '/auth/twitter', method: :post, class: 'button is-black has-text-weight-bold py-3' do
-        | TwiCode を使ってみる
+      h2.is-size-5.has-text-weight-bold
+        | TwitterでちょっとしたCodeを共有
+    - if logged_in?
+      .welcome-item
+        = link_to 'TwiCode を使ってみる', new_code_path, class: 'button is-black has-text-weight-bold is-size-5 py-3'
+    - else
+      .welcome-item
+        = link_to '/auth/twitter', method: :post, class: 'button is-black has-text-weight-bold is-size-5 py-3' do
+          | TwiCode を使ってみる
+    .welcome-item
       p
         | 利用にはTwitterログインが必要です
-  hr
-  .welcome-item
-    h2.is-size-4.has-text-weight-bold
-      | TwiCode とは？
-  .welcome-item
-    p.has-text-weight-bold
-      | 「Twitterでちょっとしたコードを共有したい！」という時
-    .columns
-      .column.is-half
-        .my-3
-          p
-            span.icon.has-text-info.is-large
-              i.far.fa-sad-tear.fa-2x
-          p テキストで投稿すると
-          p 読みにくい
-        .card
-          .card-image
-            = image_pack_tag 'top_2.png'
-      .column.is-half
-        .my-3
-          p
-            span.icon.has-text-info.is-large
-              i.far.fa-sad-tear.fa-2x
-          p 画像で投稿すると
-          p コピーできない
-        .card
-          .card-image
-            = image_pack_tag 'top_3.png'
-  .welcome-item
-    .icon.is-large
-      i.fas.fa-angle-double-down.fa-2x
-  .welcome-item
-    p
-      span.icon.has-text-success.is-large
-        i.far.fa-smile.fa-2x
-    p TwiCodeを使うと
-    p
-      span.has-text-weight-bold 読みやすい
-      span.mx-1 &
-      span.has-text-weight-bold リンク先からコードをコピーできる
-  .welcome-item
-    .card
-      .card-image
-        = image_pack_tag 'top_1.png'
-  .welcome-item
-    p
-      | TwiCodeで画像を作成し、URLをTweetすることで
-      br
-      | Twitterカードに画像が表示されます

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -8,10 +8,10 @@
         = image_pack_tag 'top_1.png'
   - if logged_in?
     .welcome-item
-      = link_to 'TwiCode を使ってみる', new_code_path, class: 'button is-info has-text-weight-bold p-5'
+      = link_to 'TwiCode を使ってみる', new_code_path, class: 'button is-black has-text-weight-bold py-3'
   - else
     .welcome-item
-      = link_to '/auth/twitter', method: :post, class: 'button is-info has-text-weight-bold p-5' do
+      = link_to '/auth/twitter', method: :post, class: 'button is-black has-text-weight-bold py-3' do
         | TwiCode を使ってみる
       p
         | 利用にはTwitterログインが必要です

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -1,3 +1,5 @@
+- content_for(:html_title) { 'Welcome' }
+
 .welcome
   .welcome-items.has-text-centered
     .welcome-item.mt-3

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -16,7 +16,7 @@
         | TwitterでちょっとしたCodeを共有
     - if logged_in?
       .welcome-item
-        = link_to 'TwiCode を使ってみる', new_code_path, class: 'button is-black has-text-weight-bold is-size-5 py-3'
+        = link_to 'TwiCode を使ってみる', root_path, class: 'button is-black has-text-weight-bold is-size-5 py-3'
     - else
       .welcome-item
         = link_to '/auth/twitter', method: :post, class: 'button is-black has-text-weight-bold is-size-5 py-3' do

--- a/app/views/welcome/privacy_policy.html.slim
+++ b/app/views/welcome/privacy_policy.html.slim
@@ -1,3 +1,5 @@
+- content_for(:html_title) { 'プライバシーポリシー' }
+
 section
   .content
     h1

--- a/app/views/welcome/tos.html.slim
+++ b/app/views/welcome/tos.html.slim
@@ -1,3 +1,5 @@
+- content_for(:html_title) { '利用規約' }
+
 section
   .content
     h1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 Rails.application.routes.draw do
-  root 'welcome#index'
+  root 'home#top'
 
   resources :code, only: [:show, :new, :create, :destroy]
   get 'users/:user_id/code', to: 'code#index', as: 'user_code_index'
 
+  get 'home', to: 'home#top', as: 'home'
   get 'welcome', to: 'welcome#index', as: 'welcome'
   get 'tos', to: 'welcome#tos', as: 'tos'
   get 'privacy_policy', to: 'welcome#privacy_policy', as: 'privacy_policy'

--- a/spec/system/code_spec.rb
+++ b/spec/system/code_spec.rb
@@ -9,8 +9,9 @@ RSpec.describe 'Code', type: :system do
   before do
     mock_twitter!
     visit root_path
-    find_link('ログイン', href: '/auth/twitter').click
+    find_link('TwiCode を使ってみる', href: '/auth/twitter').click
   end
+
   describe '新規作成' do
     before { visit new_code_path }
 
@@ -43,7 +44,7 @@ RSpec.describe 'Code', type: :system do
           expect(page).to have_content '詳細画面'
         end
         it '自動でタイトルが設定されること' do
-          expect(page).to have_content 'Code of'
+          expect(page).to have_content 'Untitled'
         end
       end
     end

--- a/spec/system/code_spec.rb
+++ b/spec/system/code_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Code', type: :system do
       end
 
       it 'Codeの保存に成功し、詳細画面に遷移すること' do
-        expect(page).to have_content '詳細画面'
+        expect(page).to have_content 'Untitled'
         expect(page).to have_content '画像を作成しました'
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe 'Code', type: :system do
           select 'Ruby', from: 'code_language'
           fill_in 'code_body', with: 'test'
           click_on '画像を作成する'
-          expect(page).to have_content '詳細画面'
+          expect(page).to have_content '画像を作成しました'
         end
         it '自動でタイトルが設定されること' do
           expect(page).to have_content 'Untitled'
@@ -61,7 +61,7 @@ RSpec.describe 'Code', type: :system do
     before do
       code = FactoryBot.create(:code, user: login_user)
       visit code_path(code)
-      expect(page).to have_content '詳細画面'
+      expect(page).to have_content 'Untitled'
     end
 
     it 'テキストコードが表示されること' do
@@ -84,8 +84,7 @@ RSpec.describe 'Code', type: :system do
       end
       context '作成したユーザー以外の場合' do
         before do
-          find('.is-hoverable').hover
-          click_on 'ログアウト'
+          find('.logout-link').click
           expect(page).to have_content 'ログアウトしました'
         end
         it 'Codeの削除ボタンが表示されないこと' do
@@ -108,7 +107,7 @@ RSpec.describe 'Code', type: :system do
     before do
       FactoryBot.create(:code, title: 'Code of login_user', user: login_user)
       FactoryBot.create(:code, title: 'Code of user_a', user: user_a)
-      click_on '投稿一覧'
+      visit user_code_index_path(login_user)
     end
 
     it 'ユーザー名が表示されること' do
@@ -116,7 +115,7 @@ RSpec.describe 'Code', type: :system do
     end
     it '画像をクリックすると詳細画面に遷移すること' do
       find('.code-image').click
-      expect(page).to have_content '詳細画面'
+      expect(page).to have_content 'Code of login_user'
     end
     it 'ユーザーが作成したCodeのみが表示されること' do
       expect(page).to have_content 'Code of login_user'

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Users', type: :system do
     context '認証が成功した時' do
       it 'ログインができる' do
         visit root_path
-        find_link('ログイン', href: '/auth/twitter').click
+        find_link('TwiCode を使ってみる', href: '/auth/twitter').click
         expect(page).to have_content('ログインしました')
       end
     end
@@ -19,7 +19,7 @@ RSpec.describe 'Users', type: :system do
       before { mock_twitter_failure! }
       it 'ログインができない' do
         visit root_path
-        find_link('ログイン', href: '/auth/twitter').click
+        find_link('TwiCode を使ってみる', href: '/auth/twitter').click
         expect(page).to have_content('キャンセルしました')
       end
     end
@@ -28,7 +28,7 @@ RSpec.describe 'Users', type: :system do
   describe 'ログアウト処理' do
     before do
       visit root_path
-      find_link('ログイン', href: '/auth/twitter').click
+      find_link('TwiCode を使ってみる', href: '/auth/twitter').click
       find('.is-hoverable').hover
       find_link('ログアウト', href: '/logout').click
     end
@@ -41,20 +41,18 @@ RSpec.describe 'Users', type: :system do
     context 'ログインしていない場合' do
       it 'ヘッダーに新規作成・投稿一覧ボタンが表示されないこと' do
         visit root_path
-        within('nav') do
-          expect(page).to_not have_content('新規作成')
-          expect(page).to_not have_content('投稿一覧')
-        end
+        expect(page).to_not have_content('新規作成')
+        expect(page).to_not have_content('投稿一覧')
       end
       it 'code新規作成画面に遷移できず、代わりにwelcome画面に遷移すること' do
         visit new_code_path
-        expect(page).to have_content('TwitterでちょっとしたCodeを共有できるサービス')
+        expect(page).to have_content('TwitterでちょっとしたCodeを共有')
       end
     end
     context 'ログインしている場合' do
       before do
         visit root_path
-        find_link('ログイン', href: '/auth/twitter').click
+        find_link('TwiCode を使ってみる', href: '/auth/twitter').click
       end
       it 'ヘッダーに新規作成・投稿一覧ボタンが表示されないこと' do
         within('nav') do
@@ -65,7 +63,7 @@ RSpec.describe 'Users', type: :system do
       it 'code新規作成画面に遷移できること' do
         visit new_code_path
         within('h1') do
-          expect(page).to have_content('新規作成')
+          expect(page).to have_content('コードの画像を作成')
         end
       end
     end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -29,8 +29,7 @@ RSpec.describe 'Users', type: :system do
     before do
       visit root_path
       find_link('TwiCode を使ってみる', href: '/auth/twitter').click
-      find('.is-hoverable').hover
-      find_link('ログアウト', href: '/logout').click
+      find('.logout-link').click
     end
     it 'ログアウトができること' do
       expect(page).to have_content('ログアウトしました')
@@ -39,10 +38,9 @@ RSpec.describe 'Users', type: :system do
 
   describe 'ログイン状態による画面表示の確認' do
     context 'ログインしていない場合' do
-      it 'ヘッダーに新規作成・投稿一覧ボタンが表示されないこと' do
+      it 'root_pathにアクセスするとwelcome画面に遷移すること' do
         visit root_path
-        expect(page).to_not have_content('新規作成')
-        expect(page).to_not have_content('投稿一覧')
+        expect(page).to have_content('TwitterでちょっとしたCodeを共有')
       end
       it 'code新規作成画面に遷移できず、代わりにwelcome画面に遷移すること' do
         visit new_code_path
@@ -54,11 +52,8 @@ RSpec.describe 'Users', type: :system do
         visit root_path
         find_link('TwiCode を使ってみる', href: '/auth/twitter').click
       end
-      it 'ヘッダーに新規作成・投稿一覧ボタンが表示されないこと' do
-        within('nav') do
-          expect(page).to have_content('新規作成')
-          expect(page).to have_content('投稿一覧')
-        end
+      it 'Homeに新規作成ボタンが表示されること' do
+        expect(page).to have_content('新しくコードを投稿する')
       end
       it 'code新規作成画面に遷移できること' do
         visit new_code_path


### PR DESCRIPTION
- close #119 

## LP
- [x]  情報を減らす
    - [x]  重要な要素を絞り込む
- [x]  レイアウト修正
- [x]  ログイン後
    - [x]  homeに飛ばす（ログイン後にLPは見れなくてもよさそう）
- [x] flashメッセージの色を修正

## 投稿一覧
- [x]  index部分を共通部品（パーシャル）にする
- [x]  レイアウトは左右に要素を振る
- [x]  えんぴつアイコンは削除
- [x]  0件の時に「投稿はありません」を追加

## Home画面
- [x]  Home画面作成
- [x]  パーシャルを適用
- [x]  routing設定
- [x]  新規投稿ボタン追加

## 新規投稿
- [x]  ページタイトル文言変更
- [x]  「画像を作成する」ボタンの色修正
- [x]  えんぴつアイコンを削除
- [x]  タイトルのプレースホルダー・デフォト値を`Untitled`に変更
- [x] コード入力のinputタグを一番上に配置
- [x]  ボタンの上下に空間を開ける

## 投稿詳細
- [x]  「Tweetする」ボタンの色とサイズを変更
- [x]  元のコードを下に配置
- [ ]  formのdisabledにする（要検討）

## ナビゲーションバー
- [x]  ドロップダウンメニューをなくす
    - [x]  ログアウトをアイコンボタンにする
- [x]  新規作成リンクをbuttonタグにする
- [x]  投稿一覧メニューを削除

## OGP設定

- [x]  Twitterカード
    - [x] titleをサービス名だけではなく投稿タイトル・言語を表示させる
    - [x] descriptionにサービスの説明を追加

## 色・テイスト
- [x]  色を絞る
    - [x] noticeカラーをprimaryカラーにする
- [x]  黄色からprimaryカラーにする
- [x]  全体的に角丸半径を大きくする
    - [x] ボタン
    - [x] box
    - [x] notice
- [ ]  全体的にマージンを取る
- [x]  タイトルにページごとのタイトルを入れる
